### PR TITLE
0.5.3: synthesis coherence — MEMEX-as-prior + cycle gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to Syke are documented here.
 
 _Nothing yet._
 
+## [0.5.3] — 2026-04-30
+
+The synthesis-coherence release. Trace analysis of post-redesign cycles
+showed the agent doing 2.6× the verification work of the pre-redesign
+baseline, driven by an open-ended synthesis instruction and missing
+"what changed since last wake" signal.
+
+- **Synthesis prompt rewritten** to frame MEMEX as the agent's prior, not
+  external state. Agent is told not to re-derive numbers, timestamps, or
+  claims already in MEMEX. Adds `syke.db is the source of truth, MEMEX is
+  its projection`. Drops the "Read the harnesses" / "Check what's already
+  known" / "Decide what's durable" license-to-explore lines that traces
+  showed inviting cross-harness verification work.
+- **Cycle gap surfaced in `<now>` block.** `Last cycle: …` line now appends
+  a relative gap label (e.g. `(15 min ago)`, `(2 h ago)`, `(3 d ago)`) so
+  the agent can size the cycle's effort against how much real time has
+  passed since the previous wake.
+- **`format_gap()` helper** added to `syke.runtime.psyche_md` for shared
+  use across production and replay.
+
 ## [0.5.2] — 2026-04-22
 
 The local-runtime hardening release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syke"
-version = "0.5.2"
+version = "0.5.3"
 description = "Local-first agentic memory for AI tools, powered by the Pi runtime."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/syke/__init__.py
+++ b/syke/__init__.py
@@ -1,3 +1,3 @@
 """Syke — Local memory for your AI tools."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/syke/llm/backends/pi_synthesis.py
+++ b/syke/llm/backends/pi_synthesis.py
@@ -600,9 +600,16 @@ def pi_synthesize(
         tz_name = _time.tzname[_time.daylight] if _time.daylight else _time.tzname[0]
 
         if last_cycle_row and last_cycle_row[0]:
+            from syke.runtime.psyche_md import format_gap
+
             last_dt = datetime.fromisoformat(last_cycle_row[0])
-            last_local = last_dt.astimezone()
-            last_synthesis_str = f"{last_local.strftime('%Y-%m-%d %H:%M')} {tz_name}"
+            last_local = last_dt.astimezone() if last_dt.tzinfo else last_dt
+            now_naive = now_local.replace(tzinfo=None) if now_local.tzinfo else now_local
+            last_naive = last_local.replace(tzinfo=None)
+            gap_str = format_gap(now_naive - last_naive)
+            last_synthesis_str = (
+                f"{last_local.strftime('%Y-%m-%d %H:%M')} {tz_name} ({gap_str})"
+            )
         else:
             last_synthesis_str = "none (first run)"
 

--- a/syke/llm/backends/pi_synthesis.py
+++ b/syke/llm/backends/pi_synthesis.py
@@ -607,9 +607,7 @@ def pi_synthesize(
             now_naive = now_local.replace(tzinfo=None) if now_local.tzinfo else now_local
             last_naive = last_local.replace(tzinfo=None)
             gap_str = format_gap(now_naive - last_naive)
-            last_synthesis_str = (
-                f"{last_local.strftime('%Y-%m-%d %H:%M')} {tz_name} ({gap_str})"
-            )
+            last_synthesis_str = f"{last_local.strftime('%Y-%m-%d %H:%M')} {tz_name} ({gap_str})"
         else:
             last_synthesis_str = "none (first run)"
 

--- a/syke/llm/backends/skills/pi_synthesis.md
+++ b/syke/llm/backends/skills/pi_synthesis.md
@@ -1,5 +1,13 @@
 A scheduled Syke synthesis cycle has started.
 
-Read the harnesses. Query syke.db. Check what's already known.
-Decide what's durable. Update memories and MEMEX if the state has changed.
-Do not wait for a user ask; this cycle's job is to keep the durable memory map current.
+The MEMEX above is your prior — you wrote it last cycle. Continue from there;
+do not re-derive numbers, timestamps, or claims already in it.
+
+syke.db is the source of truth, MEMEX is its projection. Query the DB only
+when you intend to write.
+
+The PSYCHE block above lists each harness and where its data lives. That
+layout is stable across cycles.
+
+Update memories and MEMEX if state has actually changed. This cycle's job
+is to keep the durable memory map current.

--- a/syke/runtime/psyche_md.py
+++ b/syke/runtime/psyche_md.py
@@ -12,7 +12,7 @@ PSYCHE is written once per workspace. <now>, <memex>, and <synthesis> are inject
 
 import logging
 import time as _time
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from syke.observe.catalog import active_sources, discovered_roots
@@ -20,6 +20,25 @@ from syke.observe.catalog import active_sources, discovered_roots
 logger = logging.getLogger(__name__)
 
 SYNTHESIS_PATH = Path(__file__).parent.parent / "llm" / "backends" / "skills" / "pi_synthesis.md"
+
+
+def format_gap(delta: timedelta) -> str:
+    """Format a timedelta as a compact relative-time string for the <now> block.
+
+    Used to surface "(15 min ago)" alongside the absolute Last cycle timestamp
+    so the agent can tell at a glance how long it has been since the last wake.
+    """
+    seconds = abs(delta.total_seconds())
+    if seconds < 60:
+        return "<1 min ago"
+    minutes = int(seconds // 60)
+    if minutes < 60:
+        return f"{minutes} min ago"
+    hours = int(seconds // 3600)
+    if hours < 24:
+        return f"{hours} h ago"
+    days = int(seconds // 86400)
+    return f"{days} d ago"
 
 
 def format_now_for_prompt(dt: datetime) -> str:

--- a/tests/test_build_prompt.py
+++ b/tests/test_build_prompt.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -12,8 +13,6 @@ import pytest
 
 from syke.db import SykeDB
 from syke.models import Memory
-from datetime import timedelta
-
 from syke.runtime.psyche_md import SYNTHESIS_PATH, build_prompt, format_gap
 
 NOW = "2026-04-15 14:00 PDT (UTC-7)"

--- a/tests/test_build_prompt.py
+++ b/tests/test_build_prompt.py
@@ -12,7 +12,9 @@ import pytest
 
 from syke.db import SykeDB
 from syke.models import Memory
-from syke.runtime.psyche_md import SYNTHESIS_PATH, build_prompt
+from datetime import timedelta
+
+from syke.runtime.psyche_md import SYNTHESIS_PATH, build_prompt, format_gap
 
 NOW = "2026-04-15 14:00 PDT (UTC-7)"
 
@@ -40,7 +42,8 @@ def test_default_synthesis_block_is_cycle_directive(tmp_path: Path) -> None:
     result = build_prompt(tmp_path, now=NOW)
     synthesis_block = result[result.index("<synthesis>") : result.index("</synthesis>")]
     assert "scheduled Syke synthesis cycle" in synthesis_block
-    assert "Do not wait for a user ask" in synthesis_block
+    assert "MEMEX above is your prior" in synthesis_block
+    assert "syke.db is the source of truth" in synthesis_block
     assert "Serve the ask" not in synthesis_block
 
 
@@ -203,3 +206,12 @@ def test_prompt_time_directive_can_be_disabled(tmp_path: Path) -> None:
     now_block = result[result.index("<now>") : result.index("</now>")]
     assert f"As of: {NOW}" in now_block
     assert "Ignore host `date`" not in now_block
+
+
+def test_format_gap_buckets() -> None:
+    assert format_gap(timedelta(seconds=30)) == "<1 min ago"
+    assert format_gap(timedelta(minutes=15)) == "15 min ago"
+    assert format_gap(timedelta(hours=2, minutes=30)) == "2 h ago"
+    assert format_gap(timedelta(days=3, hours=4)) == "3 d ago"
+    # Negative delta still produces a positive label
+    assert format_gap(timedelta(minutes=-15)) == "15 min ago"

--- a/tests/test_pi_client.py
+++ b/tests/test_pi_client.py
@@ -229,7 +229,7 @@ def test_rpc_stream_wait_for_terminal_state_waits_past_retryable_error() -> None
 
     threading.Thread(target=_emit, daemon=True).start()
 
-    assert stream.wait_for_terminal_state(timeout=0.2) is True
+    assert stream.wait_for_terminal_state(timeout=2.0) is True
     assert stream.get_assistant_error() is None
     assert stream.get_message_metadata()["response_id"] == "resp_final"
 
@@ -279,7 +279,7 @@ def test_rpc_stream_wait_for_terminal_state_returns_final_retry_failure() -> Non
 
     threading.Thread(target=_emit, daemon=True).start()
 
-    assert stream.wait_for_terminal_state(timeout=0.2) is True
+    assert stream.wait_for_terminal_state(timeout=2.0) is True
     assert stream.latest_retry_terminal_error() == (
         '429 {"error":{"type":"rate_limit_error","message":"busy"}}'
     )

--- a/tests/test_pi_synthesis_contract.py
+++ b/tests/test_pi_synthesis_contract.py
@@ -185,7 +185,7 @@ def test_pi_synthesize_waits_for_retry_settlement_before_marking_cycle_failed(
         def _emit() -> None:
             assert runtime._stream is not None
             stream = runtime._stream
-            time.sleep(0.01)
+            time.sleep(0.1)
             stream._events.append(
                 {
                     "type": "agent_end",
@@ -203,7 +203,7 @@ def test_pi_synthesize_waits_for_retry_settlement_before_marking_cycle_failed(
                 }
             )
             stream._done.set()
-            time.sleep(0.01)
+            time.sleep(0.1)
             stream._events.append(
                 {
                     "type": "auto_retry_start",
@@ -213,9 +213,9 @@ def test_pi_synthesize_waits_for_retry_settlement_before_marking_cycle_failed(
                     "errorMessage": '429 {"error":{"type":"rate_limit_error","message":"busy"}}',
                 }
             )
-            time.sleep(0.01)
+            time.sleep(0.1)
             stream._events.append({"type": "auto_retry_end", "success": True, "attempt": 1})
-            time.sleep(0.01)
+            time.sleep(0.1)
             stream._events.append(
                 {
                     "type": "agent_end",

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "syke"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The synthesis-coherence release. Trace analysis of post-redesign synthesis cycles showed the agent doing 2.6× the verification work of the pre-redesign baseline, driven by an open-ended synthesis instruction and a missing "what changed since last wake" temporal anchor.

## Changes

- **Synthesis prompt rewritten** (`syke/llm/backends/skills/pi_synthesis.md`) to frame MEMEX as the agent's prior, not external state. Tells the agent not to re-derive numbers, timestamps, or claims already in MEMEX. Adds the syke.db/MEMEX authority hierarchy. Drops the "Read the harnesses" / "Check what's already known" / "Decide what's durable" license-to-explore lines that traces showed inviting cross-harness verification.
- **Cycle gap surfaced** in the `<now>` block. "Last cycle: …" now appends a relative gap label (`(15 min ago)`, `(2 h ago)`, `(3 d ago)`) so the agent can size cycle effort against elapsed time.
- `format_gap()` helper in `syke.runtime.psyche_md` for shared use across production and replay.

## Non-changes (deliberately)

- No closed decision space — agency intact.
- No turn or tool budget — agency intact.
- No session continuity — each cycle is still a stateless wake.
- No new envelope shape beyond the gap label.

## Test plan

- [x] `tests/test_build_prompt.py` updated, all 19 tests pass locally.
- [x] New `test_format_gap_buckets` covers the four time buckets + negative-delta edge.
- [ ] CI: lint / build / test matrix (mac+ubuntu × py3.12+3.13) / smoke-artifact / build all green.