### PR TITLE
0.5.4: widen Pi retry-settlement grace 0.2s → 1.0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Syke are documented here.
 
 _Nothing yet._
 
+## [0.5.4] — 2026-04-30
+
+Patch — widen the Pi retry-settlement grace.
+
+- `_RETRY_SETTLEMENT_GRACE_SECONDS` raised from 0.2s to 1.0s in
+  `syke/llm/pi_client.py`. The grace window is how long the synthesis path
+  waits after a retryable `agent_end` (e.g. 429) for an `auto_retry_start`
+  to arrive before declaring the cycle failed. 200ms was tight under
+  network or scheduling jitter — slow retries got mis-classified as
+  failures. The cost of widening is at most extra wall-time for the rare
+  case of a *terminal* retryable error with no retry coming.
+
 ## [0.5.3] — 2026-04-30
 
 The synthesis-coherence release. Trace analysis of post-redesign cycles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syke"
-version = "0.5.3"
+version = "0.5.4"
 description = "Local-first agentic memory for AI tools, powered by the Pi runtime."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/syke/__init__.py
+++ b/syke/__init__.py
@@ -1,3 +1,3 @@
 """Syke — Local memory for your AI tools."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/syke/llm/pi_client.py
+++ b/syke/llm/pi_client.py
@@ -27,8 +27,11 @@ from syke.runtime.pi_settings import configure_pi_workspace
 logger = logging.getLogger(__name__)
 
 _PI_THINKING_LEVELS = frozenset({"off", "minimal", "low", "medium", "high", "xhigh"})
-# Give Pi a brief moment to emit retry state after a retryable agent_end.
-_RETRY_SETTLEMENT_GRACE_SECONDS = 0.2
+# Give Pi time to emit retry state after a retryable agent_end. Generous
+# enough to absorb network jitter on slow runners; the cost is at most this
+# much extra wall-time for cycles that hit a *terminal* retryable error
+# with no auto-retry coming (uncommon in production).
+_RETRY_SETTLEMENT_GRACE_SECONDS = 1.0
 _RPC_STOP_STDIN_GRACE_SECONDS = 0.2
 _RPC_STOP_TERM_GRACE_SECONDS = 1.0
 _SUBPROCESS_ENV_KEYS = (

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "syke"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

CI on main flaked after the v0.5.3 README revision: the retry-settlement test on `ubuntu-py3.12` saw the consumer give up before the test's `auto_retry_start` event arrived. Investigation found the **production** grace constant `_RETRY_SETTLEMENT_GRACE_SECONDS = 0.2` is the actual cause — same window applies in real synthesis cycles where Pi's auto-retry might take >200ms over slow networks.

## Change

- `syke/llm/pi_client.py`: bumped `_RETRY_SETTLEMENT_GRACE_SECONDS` from `0.2` → `1.0`.

That's it. No prompt, schema, or behavior changes apart from the timing constant.

## Why

The grace is how long the synthesis path waits after a retryable `agent_end` for an `auto_retry_start` event before declaring the cycle failed. 200ms was tight under any kind of jitter. Cost of widening: in the rare case of a *terminal* retryable error with no retry coming, synthesis takes ~800ms longer to surface failure. Acceptable for typical synthesis cycles that already take several seconds.

## Test plan

- [x] `tests/test_pi_synthesis_contract.py` and `tests/test_pi_client.py` all pass locally (42 tests, 4.7s).
- [ ] CI: lint / build / 4 test cells / smoke-artifact / build all green.