### PR TITLE
Release v0.5.5: replay/synthesis hardening + canonical memex preservation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syke"
-version = "0.5.4"
+version = "0.5.5"
 description = "Local-first agentic memory for AI tools, powered by the Pi runtime."
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -71,7 +71,7 @@ python-interpreter-path = ".venv/bin/python"
 [tool.tbump]
 
 [tool.tbump.version]
-current = "0.5.4"
+current = "0.5.5"
 regex = '''(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'''
 
 [tool.tbump.git]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ python-interpreter-path = ".venv/bin/python"
 [tool.tbump]
 
 [tool.tbump.version]
-current = "0.5.2"
+current = "0.5.4"
 regex = '''(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'''
 
 [tool.tbump.git]

--- a/syke/__init__.py
+++ b/syke/__init__.py
@@ -1,3 +1,3 @@
 """Syke — Local memory for your AI tools."""
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"

--- a/syke/llm/backends/pi_ask.py
+++ b/syke/llm/backends/pi_ask.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -284,13 +285,40 @@ def pi_ask(
                 logger.debug("Failed to persist ask trace", exc_info=True)
                 return None
 
+        def _pause_db_connection_for_agent() -> bool:
+            if not os.environ.get("SYKE_REPLAY_PAUSE_DB_CONNECTION_DURING_PI"):
+                return False
+            if getattr(db, "db_path", ":memory:") == ":memory:":
+                return False
+            try:
+                db.conn.commit()
+                db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                db.close()
+                logger.info("Replay DB connection paused while Pi ask runs")
+                return True
+            except Exception:
+                logger.warning("Failed to pause replay DB connection before Pi ask", exc_info=True)
+                return False
+
+        def _resume_db_connection_after_agent(paused: bool) -> None:
+            if not paused:
+                return
+            db._conn = db._connect_db(db.db_path)  # type: ignore[attr-defined]
+            db._in_transaction = False  # type: ignore[attr-defined]
+            db.initialize()
+            logger.info("Replay DB connection resumed after Pi ask run")
+
         try:
-            result = runtime.prompt(
-                question,
-                timeout=timeout,
-                on_event=_on_raw_event if on_event else None,
-                new_session=True,
-            )
+            db_paused_for_agent = _pause_db_connection_for_agent()
+            try:
+                result = runtime.prompt(
+                    question,
+                    timeout=timeout,
+                    on_event=_on_raw_event if on_event else None,
+                    new_session=True,
+                )
+            finally:
+                _resume_db_connection_after_agent(db_paused_for_agent)
         except Exception as exc:
             duration_ms = int((time.monotonic() - started) * 1000)
             runtime_status = _safe_runtime_status(runtime)

--- a/syke/llm/backends/pi_synthesis.py
+++ b/syke/llm/backends/pi_synthesis.py
@@ -142,9 +142,16 @@ def _validate_cycle_output() -> dict[str, object]:
         stats["memex_artifact_exists"] = False
 
     # Check syke.db
+    stats["syke_db_path"] = str(SYKE_DB)
+    stats["sqlite_module_version"] = sqlite3.sqlite_version
+    stats["syke_db_sidecars"] = {
+        candidate.name: candidate.stat().st_size
+        for candidate in (SYKE_DB, Path(f"{SYKE_DB}-wal"), Path(f"{SYKE_DB}-shm"))
+        if candidate.exists()
+    }
     if SYKE_DB.exists() and SYKE_DB.stat().st_size > 0:
         try:
-            conn = sqlite3.connect(f"file:{SYKE_DB}?mode=ro", uri=True)
+            conn = sqlite3.connect(f"file:{SYKE_DB}?mode=ro", uri=True, timeout=5)
             try:
                 tables = conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table'"
@@ -156,6 +163,14 @@ def _validate_cycle_output() -> dict[str, object]:
                         count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
                         stats["memory_count"] = count
                         break
+                integrity = conn.execute("PRAGMA integrity_check").fetchone()
+                quick = conn.execute("PRAGMA quick_check").fetchone()
+                stats["integrity_check"] = integrity[0] if integrity else None
+                stats["quick_check"] = quick[0] if quick else None
+                if stats["integrity_check"] != "ok":
+                    issues.append(f"syke.db integrity_check: {stats['integrity_check']}")
+                if stats["quick_check"] != "ok":
+                    issues.append(f"syke.db quick_check: {stats['quick_check']}")
             finally:
                 conn.close()
         except sqlite3.Error as e:
@@ -168,6 +183,23 @@ def _validate_cycle_output() -> dict[str, object]:
         "issues": issues,
         "stats": stats,
     }
+
+
+def _db_validation_issues(validation: dict[str, object]) -> list[str]:
+    issues = validation.get("issues")
+    if not isinstance(issues, list):
+        return []
+    return [
+        str(issue)
+        for issue in issues
+        if str(issue).startswith(
+            (
+                "syke.db read error",
+                "syke.db integrity_check",
+                "syke.db quick_check",
+            )
+        )
+    ]
 
 
 # ── Memex authority: canonical DB + routed workspace artifact ───────
@@ -755,6 +787,63 @@ def pi_synthesize(
         result["runtime_uptime_s"] = runtime_status.get("uptime_s")
         result["runtime_session_count"] = runtime_status.get("session_count")
         tool_call_count = len(pi_result.tool_calls)
+
+        def _fail_cycle_for_db_validation(
+            validation: dict[str, object],
+            issues: list[str],
+        ) -> dict[str, object] | None:
+            if not issues or not os.environ.get("SYKE_REPLAY_FAIL_ON_DB_VALIDATION"):
+                return None
+            error = "Cycle DB validation failed: " + "; ".join(issues)
+            logger.error(error)
+            result["status"] = "failed"
+            result["error"] = error
+            result["validation"] = validation
+            result["memex_updated"] = False
+            result["duration_ms"] = _elapsed_ms()
+            result["cost_usd"] = pi_result.cost_usd
+            result["input_tokens"] = pi_result.input_tokens
+            result["output_tokens"] = pi_result.output_tokens
+            trace_id = _persist_trace(
+                status="failed",
+                error=error,
+                output_text=pi_result.output,
+                thinking=getattr(pi_result, "thinking", []) or [],
+                transcript=transcript,
+                tool_calls=pi_result.tool_calls,
+                duration_ms=_elapsed_ms(),
+                cost_usd=pi_result.cost_usd,
+                input_tokens=pi_result.input_tokens,
+                output_tokens=pi_result.output_tokens,
+                cache_read_tokens=int(pi_result.cache_read_tokens or 0),
+                cache_write_tokens=int(pi_result.cache_write_tokens or 0),
+                provider=pi_result.provider,
+                model=pi_result.response_model,
+                response_id=pi_result.response_id,
+                stop_reason=pi_result.stop_reason,
+                runtime_reused=runtime_reused,
+                runtime_status=runtime_status,
+                extras={"memex_updated": False, "validation": validation},
+            )
+            result["trace_id"] = trace_id
+
+            if cycle_id:
+                try:
+                    db.complete_cycle_record(
+                        cycle_id=cycle_id,
+                        status="failed",
+                        cost_usd=float(pi_result.cost_usd or 0.0),
+                        input_tokens=int(pi_result.input_tokens or 0),
+                        output_tokens=int(pi_result.output_tokens or 0),
+                        cache_read_tokens=int(pi_result.cache_read_tokens or 0),
+                        duration_ms=_elapsed_ms(),
+                        completed_at_override=_completed_at_override,
+                    )
+                except Exception:
+                    pass
+
+            return result
+
         if not pi_result.ok:
             logger.error(f"Pi synthesis failed: {pi_result.error}")
             result["status"] = "failed"
@@ -803,9 +892,16 @@ def pi_synthesize(
 
         # ── 7. Validate output ──
         validation = _validate_cycle_output()
+        result["validation"] = validation
 
         if not validation["valid"]:
             logger.warning(f"Cycle output validation issues: {validation['issues']}")
+            failed_validation = _fail_cycle_for_db_validation(
+                validation,
+                _db_validation_issues(validation),
+            )
+            if failed_validation is not None:
+                return failed_validation
 
         # ── 7b. MEMEX budget enforcement ──
         # If over budget, give the agent up to 3 retries in the same session.
@@ -833,6 +929,15 @@ def pi_synthesize(
                 logger.warning("MEMEX compaction retry %d failed: %s", memex_retries, e)
                 break
             validation = _validate_cycle_output()
+            result["validation"] = validation
+            if not validation["valid"]:
+                logger.warning(f"Cycle output validation issues: {validation['issues']}")
+                failed_validation = _fail_cycle_for_db_validation(
+                    validation,
+                    _db_validation_issues(validation),
+                )
+                if failed_validation is not None:
+                    return failed_validation
 
         if validation.get("stats", {}).get("memex_over_budget"):
             token_count = validation["stats"].get("memex_tokens", 0)

--- a/syke/llm/backends/pi_synthesis.py
+++ b/syke/llm/backends/pi_synthesis.py
@@ -527,6 +527,29 @@ def pi_synthesize(
         if progress is not None:
             progress(message)
 
+    def _pause_db_connection_for_agent() -> bool:
+        if not os.environ.get("SYKE_REPLAY_PAUSE_DB_CONNECTION_DURING_PI"):
+            return False
+        if getattr(db, "db_path", ":memory:") == ":memory:":
+            return False
+        try:
+            db.conn.commit()
+            db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            db.close()
+            logger.info("Replay DB connection paused while Pi agent runs")
+            return True
+        except Exception:
+            logger.warning("Failed to pause replay DB connection before Pi", exc_info=True)
+            return False
+
+    def _resume_db_connection_after_agent(paused: bool) -> None:
+        if not paused:
+            return
+        db._conn = db._connect_db(db.db_path)  # type: ignore[attr-defined]
+        db._in_transaction = False  # type: ignore[attr-defined]
+        db.initialize()
+        logger.info("Replay DB connection resumed after Pi agent run")
+
     def _persist_trace(
         *,
         status: str,
@@ -732,12 +755,16 @@ def pi_synthesize(
                 if event_type == "response":
                     _progress("finalizing response")
 
-            pi_result = runtime.prompt(
-                prompt,
-                timeout=timeout,
-                new_session=True,
-                on_event=_on_runtime_event,
-            )
+            db_paused_for_agent = _pause_db_connection_for_agent()
+            try:
+                pi_result = runtime.prompt(
+                    prompt,
+                    timeout=timeout,
+                    new_session=True,
+                    on_event=_on_runtime_event,
+                )
+            finally:
+                _resume_db_connection_after_agent(db_paused_for_agent)
         except Exception as e:
             logger.exception("Pi runtime failed during synthesis cycle")
             failure_duration = _elapsed_ms()

--- a/syke/llm/backends/pi_synthesis.py
+++ b/syke/llm/backends/pi_synthesis.py
@@ -997,7 +997,58 @@ def pi_synthesize(
 
             return result
         except Exception as e:
-            logger.warning(f"Failed to commit post-synthesis state: {e}")
+            # The commit is part of the cycle contract. If it fails, the agent
+            # response may exist, but replay must not treat the state update as
+            # completed.
+            error = f"Post-synthesis commit failed: {e}"
+            logger.error("%s; transaction rolled back", error)
+            result["status"] = "failed"
+            result["error"] = error
+            result["memex_updated"] = False
+            result["duration_ms"] = total_duration
+            result["cost_usd"] = pi_result.cost_usd
+            result["input_tokens"] = pi_result.input_tokens
+            result["output_tokens"] = pi_result.output_tokens
+            trace_id = _persist_trace(
+                status="failed",
+                error=error,
+                output_text=pi_result.output,
+                thinking=getattr(pi_result, "thinking", []) or [],
+                transcript=transcript,
+                tool_calls=pi_result.tool_calls,
+                duration_ms=total_duration,
+                cost_usd=pi_result.cost_usd,
+                input_tokens=pi_result.input_tokens,
+                output_tokens=pi_result.output_tokens,
+                cache_read_tokens=int(pi_result.cache_read_tokens or 0),
+                cache_write_tokens=int(pi_result.cache_write_tokens or 0),
+                provider=pi_result.provider,
+                model=pi_result.response_model,
+                response_id=pi_result.response_id,
+                stop_reason=pi_result.stop_reason,
+                runtime_reused=runtime_reused,
+                runtime_status=runtime_status,
+                extras={"memex_updated": False},
+            )
+            result["trace_id"] = trace_id
+
+            if cycle_id:
+                try:
+                    db.complete_cycle_record(
+                        cycle_id=cycle_id,
+                        status="failed",
+                        memex_updated=False,
+                        cost_usd=float(pi_result.cost_usd or 0.0),
+                        input_tokens=int(pi_result.input_tokens or 0),
+                        output_tokens=int(pi_result.output_tokens or 0),
+                        cache_read_tokens=int(pi_result.cache_read_tokens or 0),
+                        completed_at_override=_completed_at_override,
+                        duration_ms=total_duration,
+                    )
+                except Exception:
+                    pass
+
+            return result
 
         result["status"] = "completed"
         result["memex_updated"] = memex_updated

--- a/syke/llm/backends/pi_synthesis.py
+++ b/syke/llm/backends/pi_synthesis.py
@@ -299,6 +299,23 @@ def _sync_memex_to_db(
     elif current_content is not None:
         canonical_content = current_content
         result["source"] = "db"
+    elif previous_content is not None:
+        canonical_content = previous_content
+        result["source"] = "previous"
+        try:
+            update_memex(db, user_id, canonical_content)
+            logger.warning(
+                "Canonical memex was missing after synthesis; restored previous memex (%d chars)",
+                len(canonical_content),
+            )
+        except Exception as e:
+            logger.error(f"Failed to restore previous canonical memex: {e}")
+            return result
+        current_content = _current_memex_content(db, user_id)
+        if current_content is None:
+            logger.error("Previous memex restore completed but canonical memex is still missing")
+            return result
+        canonical_content = current_content
     else:
         logger.error("No canonical memex available after synthesis")
         return result

--- a/syke/llm/backends/skills/pi_synthesis.md
+++ b/syke/llm/backends/skills/pi_synthesis.md
@@ -6,6 +6,10 @@ do not re-derive numbers, timestamps, or claims already in it.
 syke.db is the source of truth, MEMEX is its projection. Query the DB only
 when you intend to write.
 
+The canonical MEMEX row in syke.db uses `source_event_ids = ["__memex__"]`.
+Never delete or deactivate that row as ordinary cleanup. If nothing changed,
+leave the canonical row active and project the same MEMEX forward.
+
 The PSYCHE block above lists each harness and where its data lives. That
 layout is stable across cycles.
 

--- a/tests/test_build_prompt.py
+++ b/tests/test_build_prompt.py
@@ -43,6 +43,8 @@ def test_default_synthesis_block_is_cycle_directive(tmp_path: Path) -> None:
     assert "scheduled Syke synthesis cycle" in synthesis_block
     assert "MEMEX above is your prior" in synthesis_block
     assert "syke.db is the source of truth" in synthesis_block
+    assert 'source_event_ids = ["__memex__"]' in synthesis_block
+    assert "Never delete or deactivate that row" in synthesis_block
     assert "Serve the ask" not in synthesis_block
 
 

--- a/tests/test_pi_ask_trace_capture.py
+++ b/tests/test_pi_ask_trace_capture.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import syke.llm.backends.pi_ask as pi_ask_module
+from syke.db import SykeDB
 from syke.llm.pi_client import PiCycleResult
 from syke.runtime import workspace as workspace_module
 
@@ -82,3 +85,97 @@ def test_pi_ask_preserves_capture_trace_on_non_ok_result(
     assert trace["error"] == "Request timed out."
     assert trace["output_text"] == "Request timed out."
     assert trace["tool_calls_detail"] == [{"name": "read", "input": {"path": "packet.json"}}]
+
+
+def test_pi_ask_pauses_replay_db_connection_during_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    session_dir = tmp_path / "sessions"
+    workspace_root.mkdir(exist_ok=True)
+    session_dir.mkdir(exist_ok=True)
+
+    db = SykeDB(tmp_path / "syke.db")
+    user_id = "user"
+
+    def _prompt(*_args: object, **_kwargs: object) -> PiCycleResult:
+        with pytest.raises(sqlite3.ProgrammingError):
+            db.conn.execute("SELECT 1")
+        external = sqlite3.connect(db.db_path)
+        external.execute(
+            """INSERT INTO memories
+               (id, user_id, content, source_event_ids, created_at, updated_at, active)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "agent-memory",
+                user_id,
+                "agent wrote while parent ask connection was paused",
+                "[]",
+                "2026-03-08T00:00:00Z",
+                "2026-03-08T00:00:00Z",
+                1,
+            ),
+        )
+        external.commit()
+        external.close()
+        return PiCycleResult(
+            status="completed",
+            output="done",
+            thinking=[],
+            tool_calls=[],
+            events=[],
+            transcript=[{"role": "assistant", "content": "done"}],
+            num_turns=1,
+            duration_ms=5,
+            input_tokens=10,
+            output_tokens=4,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            cost_usd=0.0,
+            provider="kimi-coding",
+            response_model="k2p5",
+            response_id="resp_pause_db",
+            stop_reason="stop",
+            error=None,
+        )
+
+    runtime = SimpleNamespace(
+        is_alive=True,
+        prompt=_prompt,
+        status=lambda: {"workspace": str(workspace_root), "pid": 1},
+    )
+
+    monkeypatch.setenv("SYKE_REPLAY_PAUSE_DB_CONNECTION_DURING_PI", "1")
+    monkeypatch.setattr(workspace_module, "WORKSPACE_ROOT", workspace_root)
+    monkeypatch.setattr(workspace_module, "SESSIONS_DIR", session_dir)
+    monkeypatch.setattr(
+        pi_ask_module,
+        "get_pi_runtime",
+        lambda: (_ for _ in ()).throw(RuntimeError("no runtime")),
+    )
+    monkeypatch.setattr(pi_ask_module, "start_pi_runtime", lambda **_kwargs: runtime)
+    monkeypatch.setattr("syke.source_selection.get_selected_sources", lambda _user_id: [])
+
+    try:
+        answer, metadata = pi_ask_module.pi_ask(
+            db=db,
+            user_id=user_id,
+            question="what happened?",
+            transport="replay-integrated",
+            capture_trace=True,
+        )
+
+        assert answer == "done"
+        assert metadata["error"] is None
+        count = db.conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE id = 'agent-memory'"
+        ).fetchone()[0]
+        trace_count = db.conn.execute(
+            "SELECT COUNT(*) FROM rollout_traces WHERE kind = 'ask' AND user_id = ?",
+            (user_id,),
+        ).fetchone()[0]
+        assert count == 1
+        assert trace_count == 1
+    finally:
+        db.close()

--- a/tests/test_pi_synthesis_contract.py
+++ b/tests/test_pi_synthesis_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import sqlite3
 import threading
 import time
 from datetime import datetime
@@ -350,5 +351,79 @@ def test_pi_synthesize_uses_now_override_for_cycle_and_trace_timestamps(
         assert latest_cycle["completed_at"] == "2026-03-07T23:59:00-08:00"
         assert captured["started_at"].isoformat() == "2026-03-07T23:59:00-08:00"
         assert captured["completed_at"].isoformat() == "2026-03-07T23:59:00-08:00"
+    finally:
+        db.close()
+
+
+def test_pi_synthesize_marks_post_commit_exception_failed(
+    user_id: str,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db = SykeDB(tmp_path / "syke.db")
+    update_memex(db, user_id, "canonical memex")
+
+    monkeypatch.setattr(
+        pi_client,
+        "resolve_pi_launch_binding",
+        lambda model_override=None: pi_client.PiLaunchBinding(
+            provider="kimi-coding",
+            model=model_override or "k2p5",
+        ),
+    )
+    runtime = SimpleNamespace(
+        is_alive=True,
+        model="k2p5",
+        prompt=lambda *args, **kwargs: SimpleNamespace(
+            ok=True,
+            output="done",
+            duration_ms=5,
+            cost_usd=0.0,
+            input_tokens=10,
+            output_tokens=4,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            provider="kimi-coding",
+            response_model="k2p5",
+            response_id="resp_commit_fail",
+            stop_reason="stop",
+            tool_calls=[],
+            events=[],
+            transcript=[{"role": "assistant", "content": [{"type": "text", "text": "done"}]}],
+            num_turns=1,
+            thinking=[],
+        ),
+        status=lambda: {
+            "workspace": str(pi_synthesis.WORKSPACE_ROOT),
+            "pid": 1,
+            "uptime_s": 1,
+            "session_count": 1,
+        },
+    )
+
+    monkeypatch.setattr(
+        runtime_module, "get_pi_runtime", lambda: (_ for _ in ()).throw(RuntimeError())
+    )
+    monkeypatch.setattr(runtime_module, "start_pi_runtime", lambda **kwargs: runtime)
+    monkeypatch.setattr(
+        pi_synthesis,
+        "_sync_memex_to_db",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            sqlite3.OperationalError("Could not decode to UTF-8 column 'content'")
+        ),
+    )
+
+    try:
+        result = pi_synthesis.pi_synthesize(db, user_id)
+
+        assert result["status"] == "failed"
+        assert "Post-synthesis commit failed" in str(result["error"])
+        assert "Could not decode to UTF-8" in str(result["error"])
+        latest_cycle = db._conn.execute(
+            "SELECT status, memex_updated FROM cycle_records WHERE user_id = ? ORDER BY rowid DESC LIMIT 1",
+            (user_id,),
+        ).fetchone()
+        assert latest_cycle["status"] == "failed"
+        assert latest_cycle["memex_updated"] == 0
     finally:
         db.close()

--- a/tests/test_pi_synthesis_contract.py
+++ b/tests/test_pi_synthesis_contract.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 import syke.runtime as runtime_module
 from syke.db import SykeDB
 from syke.llm import pi_client
@@ -504,5 +506,93 @@ def test_pi_synthesize_marks_replay_db_validation_issue_failed(
         ).fetchone()
         assert latest_cycle["status"] == "failed"
         assert latest_cycle["memex_updated"] == 0
+    finally:
+        db.close()
+
+
+def test_pi_synthesize_pauses_replay_db_connection_during_agent(
+    user_id: str,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db = SykeDB(tmp_path / "syke.db")
+    update_memex(db, user_id, "canonical memex")
+
+    monkeypatch.setenv("SYKE_REPLAY_PAUSE_DB_CONNECTION_DURING_PI", "1")
+    monkeypatch.setattr(pi_synthesis, "_validate_cycle_output", lambda: {"valid": True, "issues": [], "stats": {}})
+    monkeypatch.setattr(
+        pi_client,
+        "resolve_pi_launch_binding",
+        lambda model_override=None: pi_client.PiLaunchBinding(
+            provider="kimi-coding",
+            model=model_override or "k2p5",
+        ),
+    )
+
+    def _prompt(*args, **kwargs) -> SimpleNamespace:
+        with pytest.raises(sqlite3.ProgrammingError):
+            db.conn.execute("SELECT 1")
+        external = sqlite3.connect(db.db_path)
+        external.execute(
+            """INSERT INTO memories
+               (id, user_id, content, source_event_ids, created_at, updated_at, active)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "agent-memory",
+                user_id,
+                "agent wrote while parent connection was paused",
+                "[]",
+                "2026-03-08T00:00:00Z",
+                "2026-03-08T00:00:00Z",
+                1,
+            ),
+        )
+        external.commit()
+        external.close()
+        return SimpleNamespace(
+            ok=True,
+            output="done",
+            duration_ms=5,
+            cost_usd=0.0,
+            input_tokens=10,
+            output_tokens=4,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            provider="kimi-coding",
+            response_model="k2p5",
+            response_id="resp_pause_db",
+            stop_reason="stop",
+            tool_calls=[],
+            events=[],
+            transcript=[{"role": "assistant", "content": [{"type": "text", "text": "done"}]}],
+            num_turns=1,
+            thinking=[],
+        )
+
+    runtime = SimpleNamespace(
+        is_alive=True,
+        model="k2p5",
+        prompt=_prompt,
+        status=lambda: {
+            "workspace": str(pi_synthesis.WORKSPACE_ROOT),
+            "pid": 1,
+            "uptime_s": 1,
+            "session_count": 1,
+        },
+    )
+
+    monkeypatch.setattr(
+        runtime_module, "get_pi_runtime", lambda: (_ for _ in ()).throw(RuntimeError())
+    )
+    monkeypatch.setattr(runtime_module, "start_pi_runtime", lambda **kwargs: runtime)
+
+    try:
+        result = pi_synthesis.pi_synthesize(db, user_id)
+
+        assert result["status"] == "completed"
+        count = db.conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE id = 'agent-memory'"
+        ).fetchone()[0]
+        assert count == 1
     finally:
         db.close()

--- a/tests/test_pi_synthesis_contract.py
+++ b/tests/test_pi_synthesis_contract.py
@@ -427,3 +427,82 @@ def test_pi_synthesize_marks_post_commit_exception_failed(
         assert latest_cycle["memex_updated"] == 0
     finally:
         db.close()
+
+
+def test_pi_synthesize_marks_replay_db_validation_issue_failed(
+    user_id: str,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db = SykeDB(tmp_path / "syke.db")
+    update_memex(db, user_id, "canonical memex")
+
+    monkeypatch.setenv("SYKE_REPLAY_FAIL_ON_DB_VALIDATION", "1")
+    monkeypatch.setattr(
+        pi_client,
+        "resolve_pi_launch_binding",
+        lambda model_override=None: pi_client.PiLaunchBinding(
+            provider="kimi-coding",
+            model=model_override or "k2p5",
+        ),
+    )
+    runtime = SimpleNamespace(
+        is_alive=True,
+        model="k2p5",
+        prompt=lambda *args, **kwargs: SimpleNamespace(
+            ok=True,
+            output="done",
+            duration_ms=5,
+            cost_usd=0.0,
+            input_tokens=10,
+            output_tokens=4,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            provider="kimi-coding",
+            response_model="k2p5",
+            response_id="resp_validation_fail",
+            stop_reason="stop",
+            tool_calls=[],
+            events=[],
+            transcript=[{"role": "assistant", "content": [{"type": "text", "text": "done"}]}],
+            num_turns=1,
+            thinking=[],
+        ),
+        status=lambda: {
+            "workspace": str(pi_synthesis.WORKSPACE_ROOT),
+            "pid": 1,
+            "uptime_s": 1,
+            "session_count": 1,
+        },
+    )
+
+    monkeypatch.setattr(
+        runtime_module, "get_pi_runtime", lambda: (_ for _ in ()).throw(RuntimeError())
+    )
+    monkeypatch.setattr(runtime_module, "start_pi_runtime", lambda **kwargs: runtime)
+    monkeypatch.setattr(
+        pi_synthesis,
+        "_validate_cycle_output",
+        lambda: {
+            "valid": False,
+            "issues": ["syke.db read error: database disk image is malformed"],
+            "stats": {"syke_db_path": str(tmp_path / "syke.db")},
+        },
+    )
+
+    try:
+        result = pi_synthesis.pi_synthesize(db, user_id)
+
+        assert result["status"] == "failed"
+        assert "Cycle DB validation failed" in str(result["error"])
+        assert result["validation"]["issues"] == [
+            "syke.db read error: database disk image is malformed"
+        ]
+        latest_cycle = db._conn.execute(
+            "SELECT status, memex_updated FROM cycle_records WHERE user_id = ? ORDER BY rowid DESC LIMIT 1",
+            (user_id,),
+        ).fetchone()
+        assert latest_cycle["status"] == "failed"
+        assert latest_cycle["memex_updated"] == 0
+    finally:
+        db.close()

--- a/tests/test_pi_synthesis_contract.py
+++ b/tests/test_pi_synthesis_contract.py
@@ -554,7 +554,9 @@ def test_pi_synthesize_pauses_replay_db_connection_during_agent(
     update_memex(db, user_id, "canonical memex")
 
     monkeypatch.setenv("SYKE_REPLAY_PAUSE_DB_CONNECTION_DURING_PI", "1")
-    monkeypatch.setattr(pi_synthesis, "_validate_cycle_output", lambda: {"valid": True, "issues": [], "stats": {}})
+    monkeypatch.setattr(
+        pi_synthesis, "_validate_cycle_output", lambda: {"valid": True, "issues": [], "stats": {}}
+    )
     monkeypatch.setattr(
         pi_client,
         "resolve_pi_launch_binding",

--- a/tests/test_pi_synthesis_contract.py
+++ b/tests/test_pi_synthesis_contract.py
@@ -139,6 +139,41 @@ def test_sync_memex_does_not_import_stale_artifact_when_nothing_changed(
     assert written.startswith("# MEMEX [")
 
 
+def test_sync_memex_restores_previous_when_canonical_row_disappears(
+    db,
+    user_id: str,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    memex_path = tmp_path / "MEMEX.md"
+    monkeypatch.setattr(pi_synthesis, "MEMEX_PATH", memex_path)
+
+    update_memex(db, user_id, "canonical memex")
+    existing = db.get_memex(user_id)
+    assert existing is not None
+    memex_path.write_text("canonical memex\n", encoding="utf-8")
+    db.conn.execute("UPDATE memories SET active = 0 WHERE id = ?", (existing["id"],))
+    db.conn.commit()
+
+    result = pi_synthesis._sync_memex_to_db(
+        db,
+        user_id,
+        previous_content="canonical memex",
+        previous_artifact_content="canonical memex",
+    )
+
+    assert result == {
+        "ok": True,
+        "updated": False,
+        "source": "previous",
+        "artifact_written": True,
+    }
+    assert db.get_memex(user_id)["content"] == "canonical memex"
+    written = memex_path.read_text(encoding="utf-8")
+    assert "canonical memex" in written
+    assert written.startswith("# MEMEX [")
+
+
 def test_pi_synthesize_skips_when_synthesis_lock_is_held(db, user_id: str) -> None:
     with patch.object(
         pi_synthesis,

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "syke"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release on top of v0.5.4. Carries the 6 follow-up commits that landed on `release/v0.5.4` after PR #39 was merged, plus the README revision from main.

### Replay / synthesis hardening
- **3d42981** Preserve replay truth when synthesis commit fails
- **f375462** Fail replay cycles when DB validation breaks
- **da93a7f** Pause replay DB ownership during Pi writes
- **8574599** Keep replay asks from sharing SQLite handles

### Canonical memex invariant
- **e5b5a25** Preserve canonical memex across synthesis cycles
- **4ded817** Clarify canonical memex synthesis invariant

### Housekeeping
- Merge in latest README revision from main (825fc48)
- Sync tbump `current` (was stale at 0.5.2) and bump to 0.5.5

Diff: 7 files, +638 / -37 (most of it new test coverage in `test_pi_ask_trace_capture.py` and `test_pi_synthesis_contract.py`).

## Test plan
- [ ] `pytest tests/test_pi_ask_trace_capture.py tests/test_pi_synthesis_contract.py`
- [ ] Full suite green
- [ ] Tag `v0.5.5` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)