### PR TITLE
Keep daemon status contract tests platform-explicit

### DIFF
--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -843,6 +843,7 @@ def test_daemon_status_json_returns_structured_payload(cli_runner) -> None:
     }
 
     with (
+        patch("syke.cli_support.daemon_state.platform.system", return_value="Darwin"),
         patch(
             "syke.cli_support.daemon_state.daemon_process_state",
             return_value={"running": True, "pid": 321, "source": "pidfile"},


### PR DESCRIPTION
This PR recovers the red main CI run by making the macOS daemon status contract test explicitly select the Darwin branch. The separate Linux/systemd contract test remains intact.

Evidence before PR:
- full local test suite: 517 passed, 8 skipped
- full local scripts/release-candidate.sh: passed
- targeted Python 3.12 contract tests: 41 passed
- isolated Python 3.13 contract tests: 41 passed
- ruff check on changed test file: passed
- git diff --check: passed

This branch contains exactly one commit and one one-line test change vs origin/main.
