### PR TITLE
Prepare v0.5.7 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to Syke are documented here.
 
 ## [Unreleased]
 
+## [0.5.7] — 2026-05-22
+
+Patch — release gates, Linux daemon parity, and timeline/MEMEX correctness.
+
 - Added a local `scripts/release-candidate.sh` gate so maintainers prove a
   candidate before pushing, tagging, or publishing.
 - Aligned maintainer docs around the release order: local candidate proof,
   pushed GitHub Actions confirmation, version/changelog bump, tag candidate
   proof, then publish workflow.
+- Fixed the daemon status contract tests so macOS launchd and Linux systemd
+  branches are exercised explicitly in CI instead of inheriting the runner
+  platform accidentally.
 - Hardened MEMEX/timeline truth surfaces: timeline ordering now sorts mixed
   timestamp offsets by instant, and trace-derived memory touches no longer
   overload canonical memory update counters.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: syke
 description: "Local-first cross-harness memory for agents. Syke observes activity across supported harnesses, keeps a current memex in context, and gives agents `syke ask`, `syke memex`, and `syke record` for continuity across sessions."
-version: 0.5.6
+version: 0.5.7
 author: saxenauts
 license: AGPL-3.0-only
 metadata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syke"
-version = "0.5.6"
+version = "0.5.7"
 description = "Local-first agentic memory for AI tools, powered by the Pi runtime."
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -74,7 +74,7 @@ python-interpreter-path = ".venv/bin/python"
 [tool.tbump]
 
 [tool.tbump.version]
-current = "0.5.6"
+current = "0.5.7"
 regex = '''(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'''
 
 [tool.tbump.git]

--- a/scripts/fresh-install-test.sh
+++ b/scripts/fresh-install-test.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   bash scripts/fresh-install-test.sh --run
-#   bash scripts/fresh-install-test.sh --run --wheel dist/syke-0.5.6-py3-none-any.whl
+#   bash scripts/fresh-install-test.sh --run --wheel dist/syke-0.5.7-py3-none-any.whl
 #   bash scripts/fresh-install-test.sh --run --provider-state "$HOME/.syke/pi-agent"
 #   bash scripts/fresh-install-test.sh --run --allow-needs-runtime
 

--- a/scripts/linux-product-qa.sh
+++ b/scripts/linux-product-qa.sh
@@ -21,7 +21,7 @@ OUTPUT_DIR=""
 
 usage() {
   cat <<'EOF'
-usage: scripts/linux-product-qa.sh --wheel dist/syke-0.5.6-py3-none-any.whl --provider-state "$HOME/.syke/pi-agent"
+usage: scripts/linux-product-qa.sh --wheel dist/syke-0.5.7-py3-none-any.whl --provider-state "$HOME/.syke/pi-agent"
 
 optional:
   --user <id>               user id inside the disposable Linux profile

--- a/syke/__init__.py
+++ b/syke/__init__.py
@@ -1,3 +1,3 @@
 """Syke — Local memory for your AI tools."""
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/syke/distribution/SKILL.md
+++ b/syke/distribution/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: syke
 description: "Local-first cross-harness memory for agents. Syke observes activity across supported harnesses, keeps a current memex in context, and gives agents `syke ask`, `syke memex`, and `syke record` for continuity across sessions."
-version: 0.5.6
+version: 0.5.7
 author: saxenauts
 license: AGPL-3.0-only
 metadata:

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "syke"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed

- Bumped the package, lockfile, and runtime version from `0.5.6` to `0.5.7`.
- Moved the release-gate/Linux/timeline/MEMEX changelog entries into the `0.5.7` section.
- Kept the distributed Syke skill manifests and script examples aligned with the new package version.

## Why

`0.5.6` is already published on PyPI and GitHub. The current release candidate needs a new patch version before tagging and publishing.

## Validation

- `uv run python scripts/check_release_tag.py v0.5.7`
- `uv run pytest tests/test_cli_contract.py::test_runtime_version_matches_project_metadata tests/test_distribution.py tests/test_version_check.py -q` -> 24 passed
- `uv run ruff check`
- `uv run ruff format --check`
- `git diff --check`
- `uv run pytest tests -q` -> 517 passed, 8 skipped
- `gitnexus detect-changes --repo syke --scope all`
- `scripts/release-candidate.sh --for-tag v0.5.7` -> passed, including preflight, build, wheel/sdist smoke installs, isolated uv tool install, fresh-agent setup smoke, and local timeline API

## Release note

This PR does not tag or publish. If GitHub Actions is green after this PR, the next gate is to merge, re-prove `main`, run `scripts/release-candidate.sh --for-tag v0.5.7` from the final main commit, then push tag `v0.5.7`.
